### PR TITLE
Deleted print_r() statement in file 'src/LatchAuth.php'.

### DIFF
--- a/src/LatchAuth.php
+++ b/src/LatchAuth.php
@@ -137,7 +137,6 @@ abstract class LatchAuth {
 
     public function HTTP($method, $url, $headers, $params) {
         $curlHeaders = array();
-        print_r($url);
         foreach ($headers as $hkey=>$hvalue) {
             array_push($curlHeaders, $hkey . ":" . $hvalue);
         }


### PR DESCRIPTION
This change has been tested by implementing this Latch SDK version in 'latch-plugin-owncloud' project, and everything works properly.